### PR TITLE
文章访问量统计功能无法正常实现，修改 post.ejs 记录文章访问量的id值，可正常

### DIFF
--- a/templates/post.ejs
+++ b/templates/post.ejs
@@ -38,7 +38,7 @@
         <% } %>
 
         <% if(site.customConfig['valine'] && site.customConfig['visitor']) { %>
-            <span id="/<%= post.link.split('/')[3] %>/" class="leancloud_visitors" data-flag-title="<%= post.title %>">
+            <span id="/<%= post.link.split('/')[3] + '/' + post.link.split('/')[4] %>/" class="leancloud_visitors" data-flag-title="<%= post.title %>">
                 <em class="post-meta-item-text">阅读量 </em>
                 <i class="leancloud-visitors-count">0</i>
             </span>


### PR DESCRIPTION
第41行，如果使用原来的id `/post/`，无法向LeanCloud正确添加数据，修改为 `/post/文章地址/` 后可正常记录文章访问量