### PR TITLE
移除 bootstrap & 统一页面标题样式

### DIFF
--- a/templates/archives.ejs
+++ b/templates/archives.ejs
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <%- include('./includes/head', { siteTitle: themeConfig.siteName }) %>
+    <%- include('./includes/head', { siteTitle: `归档 | ${themeConfig.siteName}` }) %>
 </head>
 <body>
 <div class="main gt-bg-theme-color-first">

--- a/templates/friends.ejs
+++ b/templates/friends.ejs
@@ -1,7 +1,7 @@
 <html>
 
 <head>
-    <%- include('./includes/head', { siteTitle: `友情链接 - ${themeConfig.siteName}` }) %>
+    <%- include('./includes/head', { siteTitle: `友情链接 | ${themeConfig.siteName}` }) %>
 </head>
 
 <body>

--- a/templates/includes/head.ejs
+++ b/templates/includes/head.ejs
@@ -1,6 +1,6 @@
-<meta charset="utf-8"/>
-<meta name="description" content=""/>
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta charset="utf-8" />
+<meta name="description" content="" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <title><%= siteTitle %></title>
 
@@ -8,29 +8,38 @@
 
 <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/all.min.css" rel="stylesheet">
 <link rel="stylesheet" href="<%= themeConfig.domain %>/styles/main.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.0/dist/css/bootstrap.min.css">
+<!-- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.0/dist/css/bootstrap.min.css"> -->
+
+<style>
+    hr {
+        margin-top: 1rem;
+        margin-bottom: 1rem;
+        border: 0;
+        border-top: 1px solid rgba(0, 0, 0, 0.1);
+    }
+</style>
 
 <script src="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets/highlight.min.js"></script>
 <script src="https://cdn.bootcss.com/highlight.js/9.15.10/languages/dockerfile.min.js"></script>
 <script src="https://cdn.bootcss.com/highlight.js/9.15.10/languages/dart.min.js"></script>
 
-<script src="https://cdn.jsdelivr.net/npm/moment@2.27.0/moment.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.0/dist/js/bootstrap.min.js"></script>
+<!-- <script src="https://cdn.jsdelivr.net/npm/moment@2.27.0/moment.min.js"></script> -->
+<!-- <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js"></script> -->
+<!-- <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"></script> -->
+<!-- <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.0/dist/js/bootstrap.min.js"></script> -->
 <!-- DEMO JS -->
 <!--<script src="media/scripts/index.js"></script>-->
 
 <% if (site.customConfig.ga) { %>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=<%= site.customConfig.ga %>"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= site.customConfig.ga %>"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
 
-        function gtag() {
-            dataLayer.push(arguments);
-        }
+    function gtag() {
+        dataLayer.push(arguments);
+    }
 
-        gtag('js', new Date());
-        gtag('config', '<%= site.customConfig.ga %>');
-    </script>
+    gtag('js', new Date());
+    gtag('config', '<%= site.customConfig.ga %>');
+</script>
 <% } %>

--- a/templates/includes/header.ejs
+++ b/templates/includes/header.ejs
@@ -1,3 +1,97 @@
+<style>
+    /* 导航栏样式 */
+    .navbar {
+        position: relative;
+        display: -ms-flexbox;
+        display: flex;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+        -ms-flex-align: center;
+        align-items: center;
+        -ms-flex-pack: justify;
+        justify-content: space-between;
+        padding: 0.5rem 1rem;
+    }
+
+    .navbar-brand {
+        display: inline-block;
+        padding-top: 0.3125rem;
+        padding-bottom: 0.3125rem;
+        margin-right: 1rem;
+        font-size: 1.25rem;
+        line-height: inherit;
+        white-space: nowrap;
+    }
+
+    .navbar-brand:hover,
+    .navbar-brand:focus {
+        text-decoration: none;
+    }
+
+    .navbar-nav {
+        display: -ms-flexbox;
+        display: flex;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        padding-left: 0;
+        margin-bottom: 0;
+        list-style: none;
+    }
+
+    .navbar-collapse {
+        -ms-flex-preferred-size: 100%;
+        flex-basis: 100%;
+        -ms-flex-positive: 1;
+        flex-grow: 1;
+        -ms-flex-align: center;
+        align-items: center;
+    }
+
+    .navbar-toggler {
+        padding: 0.25rem 0.75rem;
+        font-size: 1.25rem;
+        line-height: 1;
+        background-color: transparent;
+        border: 1px solid transparent;
+        border-radius: 0.25rem;
+    }
+
+    .navbar-toggler:hover,
+    .navbar-toggler:focus {
+        text-decoration: none;
+    }
+
+    @media (min-width: 992px) {
+        .navbar-expand-lg {
+            -ms-flex-flow: row nowrap;
+            flex-flow: row nowrap;
+            -ms-flex-pack: start;
+            justify-content: flex-start;
+        }
+
+        .navbar-expand-lg .navbar-nav {
+            -ms-flex-direction: row;
+            flex-direction: row;
+        }
+
+        .navbar-expand-lg .navbar-collapse {
+            display: -ms-flexbox !important;
+            display: flex !important;
+            -ms-flex-preferred-size: auto;
+            flex-basis: auto;
+        }
+
+        .navbar-expand-lg .navbar-toggler {
+            display: none;
+        }
+    }
+
+    @media (max-width: 991px) {
+        #navbarSupportedContent {
+            display: none;
+        }
+    }
+</style>
 <nav class="navbar navbar-expand-lg">
     <div class="navbar-brand">
         <img class="user-avatar" src="/images/avatar.png" alt="头像">
@@ -6,30 +100,42 @@
         </div>
     </div>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
-            aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <i class="fas fa-bars gt-c-content-color-first" style="font-size: 18px"></i>
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <div class="navbar-nav mr-auto" style="text-align: center">
             <% menus.forEach(function(menu) { %>
-                <div class="nav-item">
-                    <% if (menu.openType === 'External') { %>
-                        <a href="<%= menu.link %>" class="menu gt-a-link" target="_blank">
-                            <%= menu.name %>
-                        </a>
-                    <% } else { %>
-                        <a href="<%= menu.link %>" class="menu gt-a-link">
-                            <%= menu.name %>
-                        </a>
-                    <% } %>
-                </div>
+            <div class="nav-item">
+                <% if (menu.openType === 'External') { %>
+                <a href="<%= menu.link %>" class="menu gt-a-link" target="_blank">
+                    <%= menu.name %>
+                </a>
+                <% } else { %>
+                <a href="<%= menu.link %>" class="menu gt-a-link">
+                    <%= menu.name %>
+                </a>
+                <% } %>
+            </div>
             <% }); %>
         </div>
         <div style="text-align: center">
-            <form id="gridea-search-form" style="position: relative" data-update="<%=site.utils.now%>" action="/search/index.html">
+            <form id="gridea-search-form" style="position: relative" data-update="<%=site.utils.now%>"
+                action="/search/index.html">
                 <input class="search-input" autocomplete="off" spellcheck="false" name="q" placeholder="搜索文章" />
                 <i class="fas fa-search gt-c-content-color-first" style="position: absolute; top: 9px; left: 10px;"></i>
             </form>
         </div>
     </div>
 </nav>
+<script>
+    /* 移动端导航栏展开/收起切换 */
+    document.getElementById('changeNavbar').onclick = function () {
+        var element = document.getElementById('navbarSupportedContent');
+        if (element.style.display === 'none' || element.style.display === '') {
+            element.style.display = 'block';
+        } else {
+            element.style.display = 'none';
+        }
+    }
+</script>

--- a/templates/search.ejs
+++ b/templates/search.ejs
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-    <%- include('./includes/head', { siteTitle: `搜索 - ${themeConfig.siteName}` }) %>
+    <%- include('./includes/head', { siteTitle: `搜索 | ${themeConfig.siteName}` }) %>
     <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.4.0/dist/fuse.basic.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/ejs@3.1.3/ejs.min.js"></script>
     <script src="<%= themeConfig.domain %>/media/gridea-search/gridea-search.js"></script>

--- a/templates/tags.ejs
+++ b/templates/tags.ejs
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <%- include('./includes/head', { siteTitle: themeConfig.siteName }) %>
+    <%- include('./includes/head', { siteTitle: `标签 | ${themeConfig.siteName}` }) %>
 </head>
 <body>
 <div class="main gt-bg-theme-color-first">


### PR DESCRIPTION
预览：https://baoshuo.blog/

+ 去除 `bootstrap` `popper.js` `moment` 等不必要的代码以提升访问速度。
  + `navbar` 部分已经自己实现，无需借助 `bootstrap` 。
  + `popper.js` `moment` 在主题中并未使用到，因此移除该部分代码。
+ 统一页面标题样式。