### PR TITLE
main.css to adapt safari

### DIFF
--- a/assets/styles/main.less
+++ b/assets/styles/main.less
@@ -63,7 +63,7 @@ ul {
 
   .main-content {
     flex: 1;
-    display: flex;
+    display: block;
     min-height: 100vh;
     flex-direction: column;
     justify-content: space-between;


### PR DESCRIPTION
change main-content from 'display:flex' to 'dispaly:block' which is used in archives.ejs and tags.ejs to fix archives web in safari
the footer would be dislocated in safari in archives because of safari container mechanism
You can easily locate this bug to access https://imhanjie.com/ in safari ( PS: iOS or MacOS both can find this bug)